### PR TITLE
Replace deprecated schemes with globals

### DIFF
--- a/modules/elementor/widgets/animated-text.php
+++ b/modules/elementor/widgets/animated-text.php
@@ -8,7 +8,7 @@ use Elementor\Widget_Base;
 use Elementor\Controls_Manager;
 use Elementor\Group_Control_Image_Size;
 use \Elementor\Group_Control_Typography;
-use \Elementor\Core\Schemes\Typography;
+use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use \Elementor\Repeater;
 use Elementor\Utils;
 
@@ -272,7 +272,9 @@ class Animated_Text extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			[
              'name' => 'borderless_elementor_animated_text_prefix_typography',
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'fields_options' => [
 					'typography' => ['default' => 'yes'],
 					'font_size' => ['default' => ['size' => 24]],
@@ -325,7 +327,9 @@ class Animated_Text extends Widget_Base {
 			[
 			'label' => esc_html__( 'Animated Text Typography', 'borderless'),
 			'name' => 'borderless_elementor_animated_text_typography',
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'fields_options' => [
 					'typography' => ['default' => 'yes'],
 					'font_size' => ['default' => ['size' => 24]],
@@ -341,7 +345,9 @@ class Animated_Text extends Widget_Base {
 			[
 			'label' => esc_html__( 'Animated Text Cursor Typography', 'borderless'),
 			'name' => 'borderless_elementor_animated_text_cursor_typography',
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'fields_options' => [
 					'typography' => ['default' => 'yes'],
 					'font_size' => ['default' => ['size' => 24]],
@@ -382,7 +388,9 @@ class Animated_Text extends Widget_Base {
 			Group_Control_Typography::get_type(),
 			[
 			'name' => 'borderless_elementor_animated_text_suffix_typography',
-				'scheme' => Typography::TYPOGRAPHY_1,
+				'global' => [
+					'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+				],
 				'fields_options' => [
 					'typography' => ['default' => 'yes'],
 					'font_size' => ['default' => ['size' => 24]],

--- a/modules/elementor/widgets/circular-progress-bar.php
+++ b/modules/elementor/widgets/circular-progress-bar.php
@@ -8,7 +8,7 @@ use \Elementor\Controls_Manager;
 use \Elementor\Group_Control_Background;
 use \Elementor\Group_Control_Box_Shadow;
 use \Elementor\Group_Control_Typography;
-use \Elementor\Core\Schemes\Typography;
+use \Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use \Elementor\Widget_Base;
 
 class Circular_Progress_Bar extends Widget_Base {
@@ -346,7 +346,9 @@ class Circular_Progress_Bar extends Widget_Base {
 		[
 			'name' => 'borderless_circular_progress_bar_title_typography',
 			'label' => __('Title', 'borderless'),
-			'scheme' => Typography::TYPOGRAPHY_1,
+			'global' => [
+				'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+			],
 			'selector' => '{{WRAPPER}} .borderless-elementor-circular-progress-bar .progressbar-text .borderless-elementor-circular-progress-bar-title',
 		]
 	);
@@ -369,7 +371,9 @@ class Circular_Progress_Bar extends Widget_Base {
 		[
 			'name' => 'borderless_circular_progress_bar_counter_typography',
 			'label' => __('Counter', 'borderless'),
-			'scheme' => Typography::TYPOGRAPHY_1,
+			'global' => [
+				'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+			],
 			'selector' => '{{WRAPPER}} .borderless-elementor-circular-progress-bar .progressbar-text .borderless-elementor-circular-progress-bar-counter-value',
 		]
 	);
@@ -389,7 +393,9 @@ class Circular_Progress_Bar extends Widget_Base {
 		[
 			'name' => 'borderless_circular_progress_bar_postfix_typography',
 			'label' => __('Postfix', 'borderless'),
-			'scheme' => Typography::TYPOGRAPHY_1,
+			'global' => [
+				'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+			],
 			'selector' => '{{WRAPPER}} .borderless-elementor-circular-progress-bar-counter-postfix',
 		]
 	);

--- a/modules/elementor/widgets/hero.php
+++ b/modules/elementor/widgets/hero.php
@@ -14,7 +14,6 @@ use \Elementor\Group_Control_Background;
 use \Elementor\Group_Control_Text_Stroke;
 use \Elementor\Group_Control_Text_Shadow;
 use \Elementor\Group_Control_Css_Filter;
-use \Elementor\Core\Schemes\Typography;
 use Elementor\Icons_Manager;
 use \Elementor\Repeater;
 use Elementor\Utils;

--- a/modules/elementor/widgets/marquee-text.php
+++ b/modules/elementor/widgets/marquee-text.php
@@ -11,7 +11,7 @@ use Elementor\Group_Control_Box_Shadow;
 use Elementor\Group_Control_Image_Size;
 use \Elementor\Group_Control_Typography;
 use \Elementor\Group_Control_Background;
-use \Elementor\Core\Schemes\Typography;
+use \Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use \Elementor\Repeater;
 use Elementor\Utils;
 
@@ -204,7 +204,9 @@ class Marquee_Text extends Widget_Base {
 				[
 					'name' => 'borderless_elementor_marquee_text_typography',
 					'label' => __('Typography', 'borderless'),
-					'scheme' => Typography::TYPOGRAPHY_1,
+					'global' => [
+						'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+					],		
 					'selector' => '{{WRAPPER}} .borderless-elementor-marquee-text *',
 				]
 			);

--- a/modules/elementor/widgets/portfolio.php
+++ b/modules/elementor/widgets/portfolio.php
@@ -10,10 +10,9 @@ use Elementor\Group_Control_Border;
 use Elementor\Group_Control_Box_Shadow;
 use Elementor\Group_Control_Image_Size;
 use \Elementor\Group_Control_Typography;
-use \Elementor\Core\Schemes\Typography;
 use \Elementor\Group_Control_Background;
 use \Elementor\Group_Control_Css_Filter;
-use \Elementor\Core\Schemes\Color;
+use \Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use \Elementor\Repeater;
 use Elementor\Utils;
 
@@ -598,7 +597,9 @@ class Portfolio extends Widget_Base {
 				[
 					'name' => 'borderless_elementor_item_content_title_typography',
 					'label' => __('Typography', 'borderless'),
-					'scheme' => Typography::TYPOGRAPHY_1,
+					'global' => [
+						'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+					],		
 					'selector' => '{{WRAPPER}} .borderless-elementor-portfolio-item-title',
 				]
 			);
@@ -679,7 +680,9 @@ class Portfolio extends Widget_Base {
 				[
 					'name' => 'borderless_elementor_item_content_description_typography',
 					'label' => __('Typography', 'borderless'),
-					'scheme' => Typography::TYPOGRAPHY_1,
+					'global' => [
+						'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+					],		
 					'selector' => '{{WRAPPER}} .borderless-elementor-portfolio-item-description',
 				]
 			);
@@ -802,7 +805,9 @@ class Portfolio extends Widget_Base {
 						[
 							'name' => 'borderless_elementor_item_content_button_typography',
 							'label' => __('Typography', 'borderless'),
-							'scheme' => Typography::TYPOGRAPHY_1,
+							'global' => [
+								'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+							],				
 							'selector' => '{{WRAPPER}} .borderless-elementor-portfolio-item-button',
 						]
 					);
@@ -872,7 +877,9 @@ class Portfolio extends Widget_Base {
 						[
 							'name' => 'borderless_elementor_item_content_button_typography_hover',
 							'label' => __('Typography', 'borderless'),
-							'scheme' => Typography::TYPOGRAPHY_1,
+							'global' => [
+								'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+							],				
 							'selector' => '{{WRAPPER}} .borderless-elementor-portfolio-item-button:hover',
 						]
 					);
@@ -1061,7 +1068,9 @@ class Portfolio extends Widget_Base {
 						[
 							'name' => 'borderless_elementor_filter_item_typography',
 							'label' => __('Typography', 'borderless'),
-							'scheme' => Typography::TYPOGRAPHY_1,
+							'global' => [
+								'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+							],				
 							'selector' => '{{WRAPPER}} .borderless-elementor-portfolio-filter-item',
 						]
 					);
@@ -1131,7 +1140,9 @@ class Portfolio extends Widget_Base {
 						[
 							'name' => 'borderless_elementor_filter_item_typography_hover',
 							'label' => __('Typography', 'borderless'),
-							'scheme' => Typography::TYPOGRAPHY_1,
+							'global' => [
+								'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+							],				
 							'selector' => '{{WRAPPER}} .borderless-elementor-portfolio-filter-item:hover',
 						]
 					);
@@ -1201,7 +1212,9 @@ class Portfolio extends Widget_Base {
 						[
 							'name' => 'borderless_elementor_filter_item_typography_active',
 							'label' => __('Typography', 'borderless'),
-							'scheme' => Typography::TYPOGRAPHY_1,
+							'global' => [
+								'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+							],				
 							'selector' => '{{WRAPPER}} .borderless-elementor-portfolio-filter-item.is-checked',
 						]
 					);

--- a/modules/elementor/widgets/progress-bar.php
+++ b/modules/elementor/widgets/progress-bar.php
@@ -8,7 +8,7 @@ use \Elementor\Controls_Manager;
 use \Elementor\Group_Control_Background;
 use \Elementor\Group_Control_Box_Shadow;
 use \Elementor\Group_Control_Typography;
-use \Elementor\Core\Schemes\Typography;
+use \Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use \Elementor\Widget_Base;
 
 class Progress_Bar extends Widget_Base {
@@ -331,7 +331,9 @@ class Progress_Bar extends Widget_Base {
 		[
 			'name' => 'borderless_elementor_progress_bar_title_typography',
 			'label' => __('Title', 'borderless'),
-			'scheme' => Typography::TYPOGRAPHY_1,
+			'global' => [
+				'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+			],
 			'selector' => '{{WRAPPER}} .borderless-elementor-progress-bar .progressbar-text div .borderless-elementor-progress-bar-title',
 		]
 	);
@@ -354,7 +356,9 @@ class Progress_Bar extends Widget_Base {
 		[
 			'name' => 'borderless_elementor_progress_bar_counter_typography',
 			'label' => __('Counter', 'borderless'),
-			'scheme' => Typography::TYPOGRAPHY_1,
+			'global' => [
+				'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+			],
 			'selector' => '{{WRAPPER}} .borderless-elementor-progress-bar .progressbar-text div .borderless-elementor-progress-bar-counter-value',
 		]
 	);
@@ -374,7 +378,9 @@ class Progress_Bar extends Widget_Base {
 		[
 			'name' => 'borderless_elementor_progress_bar_postfix_typography',
 			'label' => __('Postfix', 'borderless'),
-			'scheme' => Typography::TYPOGRAPHY_1,
+			'global' => [
+				'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+			],
 			'selector' => '{{WRAPPER}} .borderless-elementor-progress-bar .progressbar-text div .borderless-elementor-progress-bar-counter-postfix',
 		]
 	);

--- a/modules/elementor/widgets/semi-circular-progress-bar.php
+++ b/modules/elementor/widgets/semi-circular-progress-bar.php
@@ -8,7 +8,7 @@ use \Elementor\Controls_Manager;
 use \Elementor\Group_Control_Background;
 use \Elementor\Group_Control_Box_Shadow;
 use \Elementor\Group_Control_Typography;
-use \Elementor\Core\Schemes\Typography;
+use \Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use \Elementor\Widget_Base;
 
 class Semi_Circular_Progress_Bar extends Widget_Base {
@@ -322,7 +322,9 @@ class Semi_Circular_Progress_Bar extends Widget_Base {
 		[
 			'name' => 'borderless_elementor_semi_circular_progress_bar_title_typography',
 			'label' => __('Title', 'borderless'),
-			'scheme' => Typography::TYPOGRAPHY_1,
+			'global' => [
+				'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+			],
 			'selector' => '{{WRAPPER}} .borderless-elementor-semi-circular-progress-bar .progressbar-text .borderless-elementor-semi-circular-progress-bar-title',
 		]
 	);
@@ -345,7 +347,9 @@ class Semi_Circular_Progress_Bar extends Widget_Base {
 		[
 			'name' => 'borderless_elementor_semi_circular_progress_bar_counter_typography',
 			'label' => __('Counter', 'borderless'),
-			'scheme' => Typography::TYPOGRAPHY_1,
+			'global' => [
+				'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+			],
 			'selector' => '{{WRAPPER}} .borderless-elementor-semi-circular-progress-bar .progressbar-text .borderless-elementor-semi-circular-progress-bar-counter-value',
 		]
 	);
@@ -365,7 +369,9 @@ class Semi_Circular_Progress_Bar extends Widget_Base {
 		[
 			'name' => 'borderless_elementor_semi_circular_progress_bar_postfix_typography',
 			'label' => __('Postfix', 'borderless'),
-			'scheme' => Typography::TYPOGRAPHY_1,
+			'global' => [
+				'default' => Global_Typography::TYPOGRAPHY_PRIMARY,
+			],
 			'selector' => '{{WRAPPER}} .borderless-elementor-semi-circular-progress-bar-counter-postfix',
 		]
 	);

--- a/modules/elementor/widgets/slider.php
+++ b/modules/elementor/widgets/slider.php
@@ -5,17 +5,14 @@ namespace Borderless\Widgets;
 if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly
 
 use Elementor\Widget_Base;
-use Elementor\Core\Kits\Documents\Tabs\Global_Colors;
 use Elementor\Core\Kits\Documents\Tabs\Global_Typography;
 use Elementor\Controls_Manager;
 use Elementor\Group_Control_Border;
 use Elementor\Group_Control_Box_Shadow;
 use Elementor\Group_Control_Image_Size;
 use \Elementor\Group_Control_Typography;
-use \Elementor\Core\Schemes\Typography;
 use \Elementor\Group_Control_Background;
 use \Elementor\Group_Control_Css_Filter;
-use \Elementor\Core\Schemes\Color;
 use \Elementor\Repeater;
 use Elementor\Utils;
 

--- a/modules/elementor/widgets/split-hero.php
+++ b/modules/elementor/widgets/split-hero.php
@@ -14,7 +14,6 @@ use \Elementor\Group_Control_Background;
 use \Elementor\Group_Control_Text_Stroke;
 use \Elementor\Group_Control_Text_Shadow;
 use \Elementor\Group_Control_Css_Filter;
-use \Elementor\Core\Schemes\Typography;
 use Elementor\Icons_Manager;
 use \Elementor\Repeater;
 use Elementor\Utils;


### PR DESCRIPTION
The plugin is using the deprecated **Schemes** mechanism that had been replaced with **Globals** in Elementor 3.0.0 (released in 2020).

Ref: https://developers.elementor.com/docs/deprecations/complex-example/